### PR TITLE
Manually implement IAccessible

### DIFF
--- a/WinFormsComInterop/ComVariant.cs
+++ b/WinFormsComInterop/ComVariant.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace WinFormsComInterop
+{
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+    internal struct ComVariant : IDisposable
+    {
+        [DllImport("olaut32.dll")]
+        private static extern int VariantClear(IntPtr pVar);
+
+        public ComVariant(object value)
+        {
+            // This is the size of the largest field in a VARIANT, the decVal field.
+            // Since VARIANT is a union, all other data types will fit in this size.
+            Handle = Marshal.AllocCoTaskMem(sizeof(ushort) + sizeof(byte) * 2 + sizeof(uint) + sizeof(ulong));
+            if (value != null) Marshal.GetNativeVariantForObject(value, Handle);
+        }
+
+        public IntPtr Handle;
+
+        public object Value => Marshal.GetObjectForNativeVariant(Handle);
+
+        public void Dispose()
+        {
+            VariantClear(Handle);
+            Marshal.FreeCoTaskMem(Handle);
+        }
+    }
+}

--- a/WinFormsComInterop/IExternalObject.cs
+++ b/WinFormsComInterop/IExternalObject.cs
@@ -13,7 +13,6 @@ namespace WinFormsComInterop
 {
     [RuntimeCallableWrapper(typeof(primitives::Interop.Ole32.IOleWindow))]
     [RuntimeCallableWrapper(typeof(primitives::Interop.Ole32.IStream))]
-    [RuntimeCallableWrapper(typeof(drawing::Interop.Ole32.IStream))]
     [RuntimeCallableWrapper(typeof(primitives::Interop.Ole32.IPersistStream))]
     [RuntimeCallableWrapper(typeof(primitives::Interop.Ole32.IPicture))]
     [RuntimeCallableWrapper(typeof(primitives::Interop.Ole32.IOleObject))]
@@ -28,9 +27,8 @@ namespace WinFormsComInterop
     [RuntimeCallableWrapper(typeof(winbase::MS.Win32.UnsafeNativeMethods.ITfContext))]
 #endif
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
-    partial class IExternalObject 
-        : Accessibility.IAccessible, 
-        primitives::Interop.Oleaut32.IEnumVariant
+    unsafe partial class IExternalObject
+        : Accessibility.IAccessible
     {
         private static Guid IID_IAccessible = new Guid("618736E0-3C3D-11CF-810C-00AA00389B71");
         private readonly IntPtr instance;
@@ -40,95 +38,516 @@ namespace WinFormsComInterop
             this.instance = instance;
         }
 
-        public void accSelect(int flagsSelect, object varChild)
+        object Accessibility.IAccessible.accParent
         {
-            throw new NotImplementedException();
-        }
-
-        public unsafe void accLocation(out int pxLeft, out int pyTop, out int pcxWidth, out int pcyHeight, object varChild)
-        {
-            // This is breaks accessibility, but at least it do not crash application.
-            pxLeft = 0;
-            pyTop = 0;
-            pcxWidth = 0;
-            pcyHeight = 0;
-            // 3 slots in IUnknown
-            // 4 slots in IDispatch
-            // 16 index in IAccessible
-            // See https://github.com/Alexpux/mingw-w64/blob/master/mingw-w64-headers/include/oleacc.h for layout.
-            //IntPtr* comDispatch = (IntPtr*)instance;
-            //IntPtr* vtbl = (IntPtr*)comDispatch[0];
-            //var accessibility = ComWrappers.ComInterfaceDispatch.GetInstance<Accessibility.IAccessible>((ComWrappers.ComInterfaceDispatch*)instance);
-            //accessibility.accLocation(out pxLeft, out pyTop, out pcxWidth, out pcyHeight, varChild);
-            //((delegate* unmanaged<IntPtr, int*, int*, int*, int*, VARIANT*, void>)vtbl[3 + 4 + 16])(accessible, &pxLeft, &pyTop, &pcxWidth, &pcyHeight, IntPtr.Zero);
-
-            if (varChild != null)
+            get
             {
-                //throw new NotImplementedException();
+                var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+                if (result != 0) throw new InvalidCastException();
+
+                try
+                {
+                    var comDispatch = (IntPtr*)thisPtr;
+                    var vtbl = (IntPtr*)comDispatch[0];
+
+                    IntPtr pResult;
+                    result = ((delegate* unmanaged<IntPtr, IntPtr*, int>)vtbl[7])(thisPtr, &pResult);
+                    if (result != 0) Marshal.ThrowExceptionForHR(result);
+
+                    return WinFormsComWrappers.Instance.GetOrCreateObjectForComInstance(pResult, CreateObjectFlags.None);
+                }
+                finally
+                {
+                    Marshal.Release(thisPtr);
+                }
             }
         }
 
-        public object accNavigate(int navDir, object varStart)
+        int Accessibility.IAccessible.accChildCount
         {
-            throw new NotImplementedException();
+            get
+            {
+                var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+                if (result != 0) throw new InvalidCastException();
+
+                try
+                {
+                    var comDispatch = (IntPtr*)thisPtr;
+                    var vtbl = (IntPtr*)comDispatch[0];
+
+                    int value;
+                    result = ((delegate* unmanaged<IntPtr, int*, int>)vtbl[8])(thisPtr, &value);
+                    if (result != 0) Marshal.ThrowExceptionForHR(result);
+
+                    return value;
+                }
+                finally
+                {
+                    Marshal.Release(thisPtr);
+                }
+            }
         }
 
-        public object accHitTest(int xLeft, int yTop)
+        object Accessibility.IAccessible.get_accChild(object index)
         {
-            throw new NotImplementedException();
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varIndex = new(index);
+                IntPtr pChild;
+                result = ((delegate* unmanaged<IntPtr, IntPtr, IntPtr*, int>)vtbl[10])(thisPtr, varIndex.Handle, &pChild);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+
+                return WinFormsComWrappers.Instance.GetOrCreateObjectForComInstance(pChild, CreateObjectFlags.None);
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
         }
 
-        public void accDoDefaultAction(object varChild)
+        string Accessibility.IAccessible.get_accName(object index)
         {
-            throw new NotImplementedException();
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varIndex = new(index);
+                IntPtr pName;
+                result = ((delegate* unmanaged<IntPtr, IntPtr, IntPtr*, int>)vtbl[11])(thisPtr, varIndex.Handle, &pName);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+
+                string retVal = Marshal.PtrToStringBSTR(pName);
+                Marshal.FreeBSTR(pName);
+                return retVal;
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
         }
 
-        public object accParent => throw new NotImplementedException();
-
-        public int accChildCount => throw new NotImplementedException();
-
-        object Accessibility.IAccessible.get_accChild(object index) => throw new NotImplementedException();
-        string Accessibility.IAccessible.get_accName(object index) => throw new NotImplementedException();
-        void Accessibility.IAccessible.set_accName(object index, string value) => throw new NotImplementedException();
-        string Accessibility.IAccessible.get_accValue(object index) => throw new NotImplementedException();
-        void Accessibility.IAccessible.set_accValue(object index, string value) => throw new NotImplementedException();
-
-        string Accessibility.IAccessible.get_accDescription(object index) => throw new NotImplementedException();
-
-        object Accessibility.IAccessible.get_accRole(object index) => throw new NotImplementedException();
-        object Accessibility.IAccessible.get_accState(object index) => throw new NotImplementedException();
-        string Accessibility.IAccessible.get_accHelp(object index) => throw new NotImplementedException();
-
-
-        public int accHelpTopic => throw new NotImplementedException();
-        int Accessibility.IAccessible.get_accHelpTopic(out string topic, object index) => throw new NotImplementedException();
-
-        string Accessibility.IAccessible.get_accKeyboardShortcut(object index) => throw new NotImplementedException();
-
-        public object accFocus => throw new NotImplementedException();
-
-        public object accSelection => throw new NotImplementedException();
-
-        string Accessibility.IAccessible.get_accDefaultAction(object index) => throw new NotImplementedException();
-
-        unsafe HRESULT IEnumVariant.Next(uint celt, IntPtr rgVar, uint* pCeltFetched)
+        string Accessibility.IAccessible.get_accValue(object index)
         {
-            throw new NotImplementedException();
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varIndex = new(index);
+                IntPtr pValue;
+                result = ((delegate* unmanaged<IntPtr, IntPtr, IntPtr*, int>)vtbl[12])(thisPtr, varIndex.Handle, &pValue);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+
+                string retVal = Marshal.PtrToStringBSTR(pValue);
+                Marshal.FreeBSTR(pValue);
+                return retVal;
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
         }
 
-        HRESULT IEnumVariant.Skip(uint celt)
+        string Accessibility.IAccessible.get_accDescription(object index)
         {
-            throw new NotImplementedException();
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varIndex = new(index);
+                IntPtr pValue;
+                result = ((delegate* unmanaged<IntPtr, IntPtr, IntPtr*, int>)vtbl[13])(thisPtr, varIndex.Handle, &pValue);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+
+                string retVal = Marshal.PtrToStringBSTR(pValue);
+                Marshal.FreeBSTR(pValue);
+                return retVal;
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
         }
 
-        HRESULT IEnumVariant.Reset()
+        object Accessibility.IAccessible.get_accRole(object index)
         {
-            throw new NotImplementedException();
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varIndex = new(index);
+                using ComVariant varRole = new(null);
+                result = ((delegate* unmanaged<IntPtr, IntPtr, IntPtr*, int>)vtbl[14])(thisPtr, varIndex.Handle, &varRole.Handle);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+
+                return varRole.Value;
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
         }
 
-        HRESULT IEnumVariant.Clone(IEnumVariant[] ppEnum)
+        object Accessibility.IAccessible.get_accState(object index)
         {
-            throw new NotImplementedException();
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varIndex = new(index);
+                using ComVariant varRole = new(null);
+                result = ((delegate* unmanaged<IntPtr, IntPtr, IntPtr*, int>)vtbl[15])(thisPtr, varIndex.Handle, &varRole.Handle);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+
+                return varRole.Value;
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
+        }
+
+        string Accessibility.IAccessible.get_accHelp(object index)
+        {
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varIndex = new(index);
+                IntPtr pValue;
+                result = ((delegate* unmanaged<IntPtr, IntPtr, IntPtr*, int>)vtbl[16])(thisPtr, varIndex.Handle, &pValue);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+
+                string retVal = Marshal.PtrToStringBSTR(pValue);
+                Marshal.FreeBSTR(pValue);
+                return retVal;
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
+        }
+        int Accessibility.IAccessible.get_accHelpTopic(out string topic, object index)
+        {
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varIndex = new(index);
+                IntPtr stringResult; int intResult;
+                result = ((delegate* unmanaged<IntPtr, IntPtr*, IntPtr, int*, int>)vtbl[17])(thisPtr, &stringResult, varIndex.Handle, &intResult);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+
+                topic = Marshal.PtrToStringBSTR(stringResult);
+                return intResult;
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
+        }
+
+        string Accessibility.IAccessible.get_accKeyboardShortcut(object index)
+        {
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varIndex = new(index);
+                IntPtr pValue;
+                result = ((delegate* unmanaged<IntPtr, IntPtr, IntPtr*, int>)vtbl[18])(thisPtr, varIndex.Handle, &pValue);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+
+                string retVal = Marshal.PtrToStringBSTR(pValue);
+                Marshal.FreeBSTR(pValue);
+                return retVal;
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
+        }
+
+        object Accessibility.IAccessible.accFocus
+        {
+            get
+            {
+                var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+                if (result != 0) throw new InvalidCastException();
+
+                try
+                {
+                    var comDispatch = (IntPtr*)thisPtr;
+                    var vtbl = (IntPtr*)comDispatch[0];
+
+                    using ComVariant retVal = new(null);
+                    result = ((delegate* unmanaged<IntPtr, IntPtr*, int>)vtbl[19])(thisPtr, &retVal.Handle);
+                    if (result != 0) Marshal.ThrowExceptionForHR(result);
+                    return retVal.Value;
+                }
+                finally
+                {
+                    Marshal.Release(thisPtr);
+                }
+            }
+        }
+
+        object Accessibility.IAccessible.accSelection
+        {
+            get
+            {
+                var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+                if (result != 0) throw new InvalidCastException();
+
+                try
+                {
+                    var comDispatch = (IntPtr*)thisPtr;
+                    var vtbl = (IntPtr*)comDispatch[0];
+
+                    using ComVariant retVal = new(null);
+                    result = ((delegate* unmanaged<IntPtr, IntPtr*, int>)vtbl[20])(thisPtr, &retVal.Handle);
+                    if (result != 0) Marshal.ThrowExceptionForHR(result);
+                    return retVal.Value;
+                }
+                finally
+                {
+                    Marshal.Release(thisPtr);
+                }
+            }
+        }
+
+        string Accessibility.IAccessible.get_accDefaultAction(object index)
+        {
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varIndex = new(index);
+                IntPtr pValue;
+                result = ((delegate* unmanaged<IntPtr, IntPtr, IntPtr*, int>)vtbl[21])(thisPtr, varIndex.Handle, &pValue);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+
+                string retVal = Marshal.PtrToStringBSTR(pValue);
+                Marshal.FreeBSTR(pValue);
+                return retVal;
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
+        }
+
+        void Accessibility.IAccessible.accSelect(int flagsSelect, object child)
+        {
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varChild = new(child);
+                result = ((delegate* unmanaged<IntPtr, int, IntPtr, int>)vtbl[22])(thisPtr, flagsSelect, varChild.Handle);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
+        }
+
+
+        void Accessibility.IAccessible.accLocation(out int pxLeft, out int pyTop, out int pcxWidth, out int pcyHeight, object child)
+        {
+            pxLeft = 0; pyTop = 0; pcxWidth = 0; pcyHeight = 0;
+
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varChild = new(child);
+
+                fixed (int* leftPtr = &pxLeft)
+                fixed (int* topPtr = &pyTop)
+                fixed (int *widthPtr = &pcxWidth)
+                fixed (int *heightPtr = &pcyHeight)
+                {
+                    result = ((delegate* unmanaged<IntPtr, int*, int*, int*, int*, IntPtr, int>)vtbl[23])(thisPtr, leftPtr, topPtr, widthPtr,  heightPtr, varChild.Handle);
+                    if (result != 0) Marshal.ThrowExceptionForHR(result);
+                }
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
+        }
+
+        object Accessibility.IAccessible.accNavigate(int navDir, object start)
+        {
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varStart = new(start);
+                using ComVariant varEnd = new(null);
+
+                result = ((delegate* unmanaged<IntPtr, int, IntPtr, IntPtr, int>)vtbl[24])(thisPtr, navDir, varStart.Handle, varEnd.Handle);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+                return varEnd.Value;
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
+        }
+
+        object Accessibility.IAccessible.accHitTest(int xLeft, int yTop)
+        {
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varID = new(null);
+                result = ((delegate* unmanaged<IntPtr, int, int, IntPtr, int>)vtbl[25])(thisPtr, xLeft, yTop, varID.Handle);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+                return varID.Value;
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
+        }
+
+        void Accessibility.IAccessible.accDoDefaultAction(object child)
+        {
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varChild = new(child);
+                result = ((delegate* unmanaged<IntPtr, IntPtr, int>)vtbl[26])(thisPtr, varChild.Handle);
+                if (result != 0) Marshal.ThrowExceptionForHR(result);
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
+        }
+
+        void Accessibility.IAccessible.set_accName(object index, string value)
+        {
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varIndex = new(index);
+                IntPtr bstr = Marshal.StringToBSTR(value);
+
+                try
+                {
+                    result = ((delegate* unmanaged<IntPtr, IntPtr, IntPtr, int>)vtbl[27])(thisPtr, varIndex.Handle, bstr);
+                    if (result != 0) Marshal.ThrowExceptionForHR(result);
+                }
+                finally
+                {
+                    Marshal.FreeBSTR(bstr);
+                }
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
+        }
+
+        void Accessibility.IAccessible.set_accValue(object index, string value)
+        {
+            var result = Marshal.QueryInterface(instance, ref IID_IAccessible, out var thisPtr);
+            if (result != 0) throw new InvalidCastException();
+
+            try
+            {
+                var comDispatch = (IntPtr*)thisPtr;
+                var vtbl = (IntPtr*)comDispatch[0];
+
+                using ComVariant varIndex = new(index);
+                IntPtr bstr = Marshal.StringToBSTR(value);
+
+                try
+                {
+                    result = ((delegate* unmanaged<IntPtr, IntPtr, IntPtr, int>)vtbl[28])(thisPtr, varIndex.Handle, bstr);
+                    if (result != 0) Marshal.ThrowExceptionForHR(result);
+                }
+                finally
+                {
+                    Marshal.FreeBSTR(bstr);
+                }
+            }
+            finally
+            {
+                Marshal.Release(thisPtr);
+            }
         }
     }
 }


### PR DESCRIPTION
IAccessible is a very strange interface. It defines property getters and setters that take arguments, which are represented in C# by `get_*` and `set_*` methods. The source generator cannot handle this syntax correctly, even if modified to recognize property get/set methods with arguments. With this change applied, the test app builds and runs without any problems after NativeAOT. I have not verified that the interface properly provides automation information to the system, because I do not know how to do so.