### PR TITLE
Plug memory leak in StringMarshaller

### DIFF
--- a/WinFormsComInterop.SourceGenerator.Tests/RuntimeCallableWrapperTest.cs
+++ b/WinFormsComInterop.SourceGenerator.Tests/RuntimeCallableWrapperTest.cs
@@ -1105,6 +1105,7 @@ namespace Foo
                     Marshal.ThrowExceptionForHR(result);
                 }
 
+                Marshal.FreeCoTaskMem(local_1);
             }
             finally
             {

--- a/WinFormsComInterop.SourceGenerator/StringMarshaller.cs
+++ b/WinFormsComInterop.SourceGenerator/StringMarshaller.cs
@@ -59,6 +59,11 @@ namespace WinFormsComInterop.SourceGenerator
             {
                 builder.AppendLine($"{Name} = Marshal.PtrToStringUni({LocalVariable});");
             }
+
+            if (RefKind != RefKind.Out && Index != -1)
+            {
+                builder.AppendLine($"Marshal.FreeCoTaskMem({LocalVariable});");
+            }
         }
     }
 }


### PR DESCRIPTION
`Marshal.StringToCoTaskMemUni()` allocates a buffer on the heap that must be released with `Marshal.FreeCoTaskMem()`. StringMarshaller did not do this; now it does. Also updated the corresponding unit test.