### PR TITLE
Make .NET 7 and WPF configurable outside of project files

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <UseNet7>false</UseNet7>
+    <UseNet7 Condition="'$(UseNet7)' == ''">false</UseNet7>
+    <GenerateWPF Condition="'$(GenerateWPF)' == ''">false</GenerateWPF>
   </PropertyGroup>
   <ItemGroup>
     <Reference Update="Accessibility">

--- a/WinFormsComInterop/WinFormsComInterop.csproj
+++ b/WinFormsComInterop/WinFormsComInterop.csproj
@@ -11,7 +11,6 @@
     <Description>ComWrappers implementation for WinForms.</Description>
     <PackageProjectUrl>https://github.com/kant2002/winformscominterop</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <GenerateWPF>false</GenerateWPF>
     <DefineConstants Condition="$(GenerateWPF) == true">$(DefineConstants);USE_WPF</DefineConstants>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
This allow me enable .NET 7 or WPF via MSBuild properties passed via CLI