### PR TITLE
Fixed array marshalling for blittable types

### DIFF
--- a/WinFormsComInterop.SourceGenerator.Tests/RuntimeCallableWrapperTest.cs
+++ b/WinFormsComInterop.SourceGenerator.Tests/RuntimeCallableWrapperTest.cs
@@ -1742,7 +1742,8 @@ namespace Foo
             {
                 var comDispatch = (System.IntPtr*)thisPtr;
                 var vtbl = (System.IntPtr*)comDispatch[0];
-                fixed (global::Foo.STATSTG* local_0 = pstatstg)
+                ref global::Foo.STATSTG pstatstgRef = ref pstatstg == null ? ref *(global::Foo.STATSTG*)0 : ref MemoryMarshal.GetArrayDataReference(pstatstg);
+                fixed (global::Foo.STATSTG* local_0 = &pstatstgRef)
                 result = ((delegate* unmanaged<System.IntPtr, global::Foo.STATSTG*, int>)vtbl[3])(thisPtr, local_0);
                 if (result != 0)
                 {

--- a/WinFormsComInterop.SourceGenerator/BlittableArrayMarshaller.cs
+++ b/WinFormsComInterop.SourceGenerator/BlittableArrayMarshaller.cs
@@ -9,9 +9,13 @@ namespace WinFormsComInterop.SourceGenerator
         {
             get
             {
-                return ElementType.FormatType(TypeAlias) + "*";
+                return ElementTypeName + "*";
             }
         }
+
+        internal string ArrayFirstElementRefName => Name + "Ref";
+
+        internal string ElementTypeName => ElementType.FormatType(TypeAlias);
 
         public override void DeclareLocalParameter(IndentedStringBuilder builder)
         {
@@ -23,11 +27,19 @@ namespace WinFormsComInterop.SourceGenerator
             return LocalVariable;
         }
 
+        public override void ConvertToUnmanagedParameter(IndentedStringBuilder builder)
+        {
+            if (RefKind == RefKind.None)
+            {
+                builder.AppendLine($"ref {ElementTypeName} {ArrayFirstElementRefName} = ref {Name} == null ? ref *({UnmanagedTypeName})0 : ref MemoryMarshal.GetArrayDataReference({Name});");
+            }
+        }
+
         public override void PinParameter(IndentedStringBuilder builder)
         {
             if (RefKind == RefKind.None)
             {
-                builder.AppendLine($"fixed ({UnmanagedTypeName} {LocalVariable} = {Name})");
+                builder.AppendLine($"fixed ({UnmanagedTypeName} {LocalVariable} = &{ArrayFirstElementRefName})");
             }
         }
 


### PR DESCRIPTION
Built-in COM marshalling give address of the first element if array is not null.
Even for zero-length arrays. Pinning on the other hand return null if zero-length arrays.
This fix #26