### PR TITLE
Fix names of source generator files in IDE

### DIFF
--- a/WinFormsComInterop.SourceGenerator/WrapperGenerationContext.cs
+++ b/WinFormsComInterop.SourceGenerator/WrapperGenerationContext.cs
@@ -46,7 +46,8 @@ namespace WinFormsComInterop.SourceGenerator
                 {
                     foreach (var alias in metadataReference.Properties.Aliases)
                     {
-                        aliasMap.Add(Path.GetFileNameWithoutExtension(metadataReference.Display), alias);
+                        var assemblySymbol = this.context.Compilation.GetAssemblyOrModuleSymbol(metadataReference);
+                        aliasMap.Add(assemblySymbol!.Name, alias);
                     }
                 }
             }


### PR DESCRIPTION
Resolve assembly symbol from metadata by applying suggestions from https://github.com/dotnet/roslyn/issues/54073#issuecomment-942840337